### PR TITLE
Remove iterate over empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,3 +21,8 @@ Changes:
 * Added `.max_size()` function
 * `.get()` and `.get_exact()` now return a reference to the `BumpyEntry` rather than a new `BumpyEntry` with a reference to the object `T`
 * Add `.get_mut()` and `.get_exact_mut()` functions
+
+# Version 0.0.4
+
+Changes:
+* Remove `iterate_over_empty` as an option

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,11 +18,12 @@ Changes:
 # Version 0.0.3
 
 Changes:
-* Added `.max_size()` function
-* `.get()` and `.get_exact()` now return a reference to the `BumpyEntry` rather than a new `BumpyEntry` with a reference to the object `T`
-* Add `.get_mut()` and `.get_exact_mut()` functions
+* Added `.max_size()` function [#10]
+* `.get()` and `.get_exact()` now return a reference to the `BumpyEntry` rather than a new `BumpyEntry` with a reference to the object `T` [#10]
+* Add `.get_mut()` and `.get_exact_mut()` functions [#10]
 
 # Version 0.0.4
 
 Changes:
-* Remove `iterate_over_empty` as an option
+* Remove `iterate_over_empty` as an option [#11]
+* Simplify iterator code [#11]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bumpy_vector"
-version = "0.0.3"
+version = "0.0.4"
 authors = ["iagox86 <ron-git@skullsecurity.org>"]
 edition = "2018"
 description = "A Vector-like object with different sized entries"


### PR DESCRIPTION
Iterating over empty complicates the code a bit much. I'll probably add it back in the future, in some way - if I can figure out a nice way to do it.