### PR TITLE
Change index/size combos to std::ops::Range throughout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,3 +34,4 @@ Changes:
 * Add `trait AutoBumpyEntry`, to simplify entries that know their own
   size/index [#12]
 * Change error handling to use `SimpleResult` [#13]
+* Change the index..size stuff to use `std::ops::Range`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,4 +34,5 @@ Changes:
 * Add `trait AutoBumpyEntry`, to simplify entries that know their own
   size/index [#12]
 * Change error handling to use `SimpleResult` [#13]
-* Change the index..size stuff to use `std::ops::Range`
+* Change the index..size stuff to use `std::ops::Range` [#14]
+  * Note that this breaks compatibility

--- a/README.md
+++ b/README.md
@@ -26,19 +26,18 @@ let mut v: BumpyVector<String> = BumpyVector::new(100);
 // Create a 10-byte entry at the start
 let entry: BumpyEntry<String> = BumpyEntry {
   entry: String::from("hello"),
-  size: 10,
-  index: 0,
+  range: 0..10,
 };
 
 // Insert it into the BumpyVector
 assert!(v.insert(entry).is_ok());
 
 // Create another entry, this time from a tuple, that overlaps the first
-let entry: BumpyEntry<String> = (String::from("error"), 1, 5).into();
+let entry: BumpyEntry<String> = (String::from("error"), 1..6).into();
 assert!(v.insert(entry).is_err());
 
 // Create an entry that's off the end of the object
-let entry: BumpyEntry<String> = (String::from("error"), 1000, 5).into();
+let entry: BumpyEntry<String> = (String::from("error"), 1000..1005).into();
 assert!(v.insert(entry).is_err());
 
 // There is still one entry in this vector
@@ -63,7 +62,7 @@ use bumpy_vector::BumpyVector;
 // Assumes "serialize" feature is enabled: `bumpy_vector = { features = ["serialize"] }`
 fn main() {
     let mut h: BumpyVector<String> = BumpyVector::new(10);
-    h.insert((String::from("a"), 1, 2).into()).unwrap();
+    h.insert((String::from("a"), 1..3).into()).unwrap();
 
     // Serialize
     let serialized = ron::ser::to_string(&h).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![feature(range_is_empty)]
+
 //! [![Crate](https://img.shields.io/crates/v/bumpy_vector.svg)](https://crates.io/crates/bumpy_vector)
 //!
 //! A vector-like object where elements can be larger than one item. We use
@@ -72,6 +74,7 @@
 //! ```
 
 use std::collections::HashMap;
+use std::ops::Range;
 
 use simple_error::{SimpleResult, bail};
 
@@ -110,8 +113,7 @@ use serde::{Serialize, Deserialize};
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct BumpyEntry<T> {
     pub entry: T,
-    pub index: usize,
-    pub size: usize,
+    pub range: Range<usize>,
 }
 
 /// Implemented by a type that knows how to be a BumpyEntry.
@@ -156,16 +158,14 @@ pub struct BumpyEntry<T> {
 /// ```
 
 pub trait AutoBumpyEntry {
-    fn index(&self) -> usize;
-    fn size(&self) -> usize;
+    fn range(&self) -> Range<usize>;
 }
 
-impl<T> From<(T, usize, usize)> for BumpyEntry<T> {
-    fn from(o: (T, usize, usize)) -> Self {
+impl<T> From<(T, Range<usize>)> for BumpyEntry<T> {
+    fn from(o: (T, Range<usize>)) -> Self {
         BumpyEntry {
           entry: o.0,
-          index: o.1,
-          size: o.2,
+          range: o.1.clone(),
         }
     }
 }
@@ -176,15 +176,13 @@ where
 {
     fn from(o: T) -> Self
     {
-        // Pull these out, since the entry we create takes ownership of the
-        // object
-        let index = o.index();
-        let size = o.size();
+        // Pull this out before putting the entry in the list
+        let range = o.range().clone();
 
+        // Just use the built-in range. There might be a better way to do this?
         BumpyEntry {
           entry: o,
-          index: index,
-          size: size,
+          range: range,
         }
     }
 }
@@ -235,8 +233,10 @@ impl<'a, T> BumpyVector<T> {
             match self.data.get(&index) {
                 // If there's a value, we're set!
                 Some(d) => {
-                    // If we were too far away, it doesn't count. No value!
-                    if d.size <= (starting_index - index) {
+                    // If we've found a value that doesn't overlap with the
+                    // index we're looking for, that means the original index
+                    // had nothing
+                    if !d.range.contains(&starting_index) {
                         return None;
                     }
 
@@ -290,28 +290,28 @@ impl<'a, T> BumpyVector<T> {
     /// assert!(v.insert(("hello", 100, 1).into()).is_err());
     /// ```
     pub fn insert(&mut self, entry: BumpyEntry<T>) -> SimpleResult<()> {
-        if entry.size == 0 {
-            bail!("Zero is an invalid size for an entry");
+        if entry.range.is_empty() {
+            bail!("An entry can't have an empty range");
         }
 
-        if entry.index + entry.size > self.max_size {
+        if entry.range.end > self.max_size {
             bail!("Invalid entry: entry exceeds max size");
         }
 
         // Check if there's a conflict on the left
-        if self.get_entry_start(entry.index).is_some() {
+        if self.get_entry_start(entry.range.start).is_some() {
             bail!("Invalid entry: overlaps another object");
         }
 
         // Check if there's a conflict on the right
-        for x in entry.index..(entry.index + entry.size) {
+        for x in entry.range.clone() {
             if self.data.contains_key(&x) {
                 bail!("Invalid entry: overlaps another object");
             }
         }
 
         // We're good, so create an entry!
-        self.data.insert(entry.index, entry);
+        self.data.insert(entry.range.start, entry);
 
         Ok(())
     }
@@ -408,10 +408,10 @@ impl<'a, T> BumpyVector<T> {
     /// assert_eq!(2, v.remove_range(0, 10).len());
     /// assert_eq!(0, v.remove_range(0, 10).len());
     /// ```
-    pub fn remove_range(&mut self, index: usize, length: usize) -> Vec<BumpyEntry<T>> {
+    pub fn remove_range(&mut self, range: Range<usize>) -> Vec<BumpyEntry<T>> {
         let mut result: Vec<BumpyEntry<T>> = Vec::new();
 
-        for i in index..(index+length) {
+        for i in range {
             if let Some(e) = self.remove(i) {
                 result.push(e);
             }
@@ -587,29 +587,29 @@ impl<'a, T> BumpyVector<T> {
     ///
     /// Panics if an entry's size is 0. That shouldn't be possible short of
     /// tinkering with internal state (most likely modifying serialized data).
-    pub fn get_range(&self, start: usize, length: usize) -> Vec<&BumpyEntry<T>> {
+    pub fn get_range(&self, range: Range<usize>) -> Vec<&BumpyEntry<T>> {
         // We're stuffing all of our data into a vector to iterate over it
         let mut result: Vec<&BumpyEntry<T>> = Vec::new();
 
         // Start at the first entry left of what they wanted, if it exists
-        let mut i = match self.get_entry_start(start) {
+        let mut i = match self.get_entry_start(range.start) {
             Some(e) => e,
-            None    => start,
+            None    => range.start,
         };
 
         // Loop up to <length> bytes after the starting index
-        while i < start + length && i < self.max_size {
+        while i < range.end && i < self.max_size {
             // Pull the entry out, if it exists
             if let Some(e) = self.data.get(&i) {
                 // Add the entry to the vector, and jump over it
                 result.push(e);
 
                 // Prevent an infinite loop
-                if e.size == 0 {
-                    panic!("Entry size cannot be 0!");
+                if e.range.is_empty() {
+                    panic!("Entry cannot be empty!");
                 }
 
-                i += e.size;
+                i = e.range.end;
             } else {
                 i += 1;
             }
@@ -639,7 +639,7 @@ impl<'a, T> IntoIterator for &'a BumpyVector<T> {
     type IntoIter = std::vec::IntoIter<&'a BumpyEntry<T>>;
 
     fn into_iter(self) -> std::vec::IntoIter<&'a BumpyEntry<T>> {
-        return self.get_range(0, self.max_size).into_iter();
+        return self.get_range(0..self.max_size).into_iter();
     }
 }
 
@@ -653,7 +653,7 @@ mod tests {
         let mut h: BumpyVector<&str> = BumpyVector::new(100);
 
         // Insert a 5-byte value at 10
-        h.insert(("hello", 10, 5).into()).unwrap();
+        h.insert(("hello", 10..15).into()).unwrap();
         assert_eq!(1, h.len());
 
         // Earlier values are none
@@ -663,24 +663,19 @@ mod tests {
         // Middle values are all identical, no matter where in the entry we
         // retrieve it
         assert_eq!("hello", h.get(10).unwrap().entry);
-        assert_eq!(10,      h.get(10).unwrap().index);
-        assert_eq!(5,       h.get(10).unwrap().size);
+        assert_eq!(10..15,  h.get(10).unwrap().range);
 
         assert_eq!("hello", h.get(11).unwrap().entry);
-        assert_eq!(10,      h.get(11).unwrap().index);
-        assert_eq!(5,       h.get(11).unwrap().size);
+        assert_eq!(10..15,  h.get(11).unwrap().range);
 
         assert_eq!("hello", h.get(12).unwrap().entry);
-        assert_eq!(10,      h.get(12).unwrap().index);
-        assert_eq!(5,       h.get(12).unwrap().size);
+        assert_eq!(10..15,  h.get(12).unwrap().range);
 
         assert_eq!("hello", h.get(13).unwrap().entry);
-        assert_eq!(10,      h.get(13).unwrap().index);
-        assert_eq!(5,       h.get(13).unwrap().size);
+        assert_eq!(10..15,  h.get(13).unwrap().range);
 
         assert_eq!("hello", h.get(14).unwrap().entry);
-        assert_eq!(10,      h.get(14).unwrap().index);
-        assert_eq!(5,       h.get(14).unwrap().size);
+        assert_eq!(10..15,  h.get(14).unwrap().range);
 
         // Last couple entries are none
         assert!(h.get(15).is_none());
@@ -695,7 +690,7 @@ mod tests {
         let mut h: BumpyVector<&str> = BumpyVector::new(100);
 
         // Insert a 0-byte array
-        assert!(h.insert(("hello", 10, 0).into()).is_err());
+        assert!(h.insert(("hello", 10..10).into()).is_err());
         assert_eq!(0, h.len());
     }
 
@@ -704,24 +699,24 @@ mod tests {
         let mut h: BumpyVector<&str> = BumpyVector::new(100);
 
         // Insert a 2-byte value at 10
-        h.insert(("hello", 10, 2).into()).unwrap();
+        h.insert(("hello", 10..12).into()).unwrap();
         assert_eq!(1, h.len());
 
         // We can insert before
-        assert!(h.insert(("ok", 8,  1).into()).is_ok());
+        assert!(h.insert(("ok", 8..9).into()).is_ok());
         assert_eq!(2, h.len());
-        assert!(h.insert(("ok", 9,  1).into()).is_ok());
+        assert!(h.insert(("ok", 9..10).into()).is_ok());
         assert_eq!(3, h.len());
 
         // We can't insert within
-        assert!(h.insert(("error", 10, 1).into()).is_err());
-        assert!(h.insert(("error", 11, 1).into()).is_err());
+        assert!(h.insert(("error", 10..11).into()).is_err());
+        assert!(h.insert(("error", 11..12).into()).is_err());
         assert_eq!(3, h.len());
 
         // We can insert after
-        assert!(h.insert(("ok", 12, 1).into()).is_ok());
+        assert!(h.insert(("ok", 12..13).into()).is_ok());
         assert_eq!(4, h.len());
-        assert!(h.insert(("ok", 13, 1).into()).is_ok());
+        assert!(h.insert(("ok", 13..14).into()).is_ok());
         assert_eq!(5, h.len());
     }
 
@@ -729,21 +724,21 @@ mod tests {
     fn test_overlapping_multi_byte_inserts() {
         // Define 10-12, put something at 7-9 (good!)
         let mut h: BumpyVector<&str> = BumpyVector::new(100);
-        h.insert(("hello", 10, 3).into()).unwrap();
-        assert!(h.insert(("ok", 7,  3).into()).is_ok());
+        h.insert(("hello", 10..13).into()).unwrap();
+        assert!(h.insert(("ok", 7..10).into()).is_ok());
 
         // Define 10-12, try every overlapping bit
         let mut h: BumpyVector<&str> = BumpyVector::new(100);
-        h.insert(BumpyEntry::from(("hello", 10, 3))).unwrap();
-        assert!(h.insert(("error", 8,  3).into()).is_err());
-        assert!(h.insert(("error", 9,  3).into()).is_err());
-        assert!(h.insert(("error", 10, 3).into()).is_err());
-        assert!(h.insert(("error", 11, 3).into()).is_err());
-        assert!(h.insert(("error", 12, 3).into()).is_err());
+        h.insert(BumpyEntry::from(("hello", 10..13))).unwrap();
+        assert!(h.insert(("error", 8..11).into()).is_err());
+        assert!(h.insert(("error", 9..12).into()).is_err());
+        assert!(h.insert(("error", 10..13).into()).is_err());
+        assert!(h.insert(("error", 11..14).into()).is_err());
+        assert!(h.insert(("error", 12..15).into()).is_err());
 
         // 6-9 and 13-15 will work
-        assert!(h.insert(BumpyEntry::from(("ok", 6,  3))).is_ok());
-        assert!(h.insert(("ok", 13, 3).into()).is_ok());
+        assert!(h.insert(BumpyEntry::from(("ok", 6..9))).is_ok());
+        assert!(h.insert(("ok", 13..16).into()).is_ok());
         assert_eq!(3, h.len());
     }
 
@@ -751,29 +746,27 @@ mod tests {
     fn test_remove() {
         // Define 10-12, put something at 7-9 (good!)
         let mut h: BumpyVector<&str> = BumpyVector::new(100);
-        h.insert(("hello", 8, 2).into()).unwrap();
-        h.insert(("hello", 10, 2).into()).unwrap();
-        h.insert(("hello", 12, 2).into()).unwrap();
+        h.insert(("hello", 8..10).into()).unwrap();
+        h.insert(("hello", 10..12).into()).unwrap();
+        h.insert(("hello", 12..14).into()).unwrap();
         assert_eq!(3, h.len());
 
         // Remove from the start of an entry
         let e = h.remove(10).unwrap();
         assert_eq!("hello", e.entry);
-        assert_eq!(10,      e.index);
-        assert_eq!(2,       e.size);
+        assert_eq!(10..12,  e.range);
         assert_eq!(2,       h.len());
         assert!(h.get(10).is_none());
         assert!(h.get(11).is_none());
 
         // Put it back
-        h.insert(("hello", 10, 2).into()).unwrap();
+        h.insert(("hello", 10..12).into()).unwrap();
         assert_eq!(3, h.len());
 
         // Remove from the middle of an entry
         let e = h.remove(11).unwrap();
         assert_eq!("hello", e.entry);
-        assert_eq!(10,      e.index);
-        assert_eq!(2,       e.size);
+        assert_eq!(10..12,  e.range);
         assert_eq!(2,       h.len());
         assert!(h.get(10).is_none());
         assert!(h.get(11).is_none());
@@ -784,8 +777,7 @@ mod tests {
 
         let e = h.remove(13).unwrap();
         assert_eq!("hello", e.entry);
-        assert_eq!(12,      e.index);
-        assert_eq!(2,       e.size);
+        assert_eq!(12..14,  e.range);
         assert_eq!(1,       h.len());
         assert!(h.get(12).is_none());
         assert!(h.get(13).is_none());
@@ -799,17 +791,15 @@ mod tests {
     #[test]
     fn test_beginning() {
         let mut h: BumpyVector<&str> = BumpyVector::new(10);
-        h.insert(("hello", 0, 2).into()).unwrap();
+        h.insert(("hello", 0..2).into()).unwrap();
 
         assert_eq!(1, h.len());
 
         assert_eq!("hello", h.get(0).unwrap().entry);
-        assert_eq!(0,       h.get(0).unwrap().index);
-        assert_eq!(2,       h.get(0).unwrap().size);
+        assert_eq!(0..2,    h.get(0).unwrap().range);
 
         assert_eq!("hello", h.get(1).unwrap().entry);
-        assert_eq!(0,       h.get(1).unwrap().index);
-        assert_eq!(2,       h.get(1).unwrap().size);
+        assert_eq!(0..2,    h.get(1).unwrap().range);
 
         assert!(h.get(2).is_none());
     }
@@ -820,24 +810,24 @@ mod tests {
         let mut h: BumpyVector<&str> = BumpyVector::new(10);
         assert_eq!(10, h.max_size());
 
-        h.insert(("hello", 7, 3).into()).unwrap();
+        h.insert(("hello", 7..10).into()).unwrap();
         assert_eq!(1, h.len());
 
         // Inserting at 8-9-10 and onward does not
         let mut h: BumpyVector<&str> = BumpyVector::new(10);
-        assert!(h.insert(("hello", 8, 3).into()).is_err());
+        assert!(h.insert(("hello", 8..11).into()).is_err());
         assert_eq!(0, h.len());
 
         let mut h: BumpyVector<&str> = BumpyVector::new(10);
-        assert!(h.insert(("hello", 9, 3).into()).is_err());
+        assert!(h.insert(("hello", 9..12).into()).is_err());
         assert_eq!(0, h.len());
 
         let mut h: BumpyVector<&str> = BumpyVector::new(10);
-        assert!(h.insert(("hello", 10, 3).into()).is_err());
+        assert!(h.insert(("hello", 10..13).into()).is_err());
         assert_eq!(0, h.len());
 
         let mut h: BumpyVector<&str> = BumpyVector::new(10);
-        assert!(h.insert(("hello", 11, 3).into()).is_err());
+        assert!(h.insert(("hello", 11..14).into()).is_err());
         assert_eq!(0, h.len());
     }
 
@@ -845,70 +835,64 @@ mod tests {
     fn test_remove_range() {
         // Create an object
         let mut h: BumpyVector<&str> = BumpyVector::new(100);
-        h.insert(("hello", 8, 2).into()).unwrap();
-        h.insert(("hello", 10, 2).into()).unwrap();
-        h.insert(("hello", 12, 2).into()).unwrap();
+        h.insert(("hello", 8..10).into()).unwrap();
+        h.insert(("hello", 10..12).into()).unwrap();
+        h.insert(("hello", 12..14).into()).unwrap();
         assert_eq!(3, h.len());
 
         // Test removing the first two entries
-        let result = h.remove_range(8, 4);
+        let result = h.remove_range(8..12);
         assert_eq!(1, h.len());
         assert_eq!(2, result.len());
 
         assert_eq!("hello", result[0].entry);
-        assert_eq!(8,       result[0].index);
-        assert_eq!(2,       result[0].size);
+        assert_eq!(8..10,   result[0].range);
 
         assert_eq!("hello", result[1].entry);
-        assert_eq!(10,      result[1].index);
-        assert_eq!(2,       result[1].size);
+        assert_eq!(10..12,  result[1].range);
 
         // Re-create the object
         let mut h: BumpyVector<&str> = BumpyVector::new(100);
-        h.insert(("hello", 8, 2).into()).unwrap();
-        h.insert(("hello", 10, 2).into()).unwrap();
-        h.insert(("hello", 12, 2).into()).unwrap();
+        h.insert(("hello", 8..10).into()).unwrap();
+        h.insert(("hello", 10..12).into()).unwrap();
+        h.insert(("hello", 12..14).into()).unwrap();
         assert_eq!(3, h.len());
 
         // Test where the first entry starts left of the actual starting index
-        let result = h.remove_range(9, 2);
+        let result = h.remove_range(9..11);
         assert_eq!(1, h.len());
         assert_eq!(2, result.len());
 
         assert_eq!("hello", result[0].entry);
-        assert_eq!(8,       result[0].index);
-        assert_eq!(2,       result[0].size);
+        assert_eq!(8..10,   result[0].range);
 
         assert_eq!("hello", result[1].entry);
-        assert_eq!(10,      result[1].index);
-        assert_eq!(2,       result[1].size);
+        assert_eq!(10..12,  result[1].range);
 
         // Re-create the object
         let mut h: BumpyVector<&str> = BumpyVector::new(100);
-        h.insert(("hello", 8, 2).into()).unwrap();
-        h.insert(("hello", 10, 2).into()).unwrap();
-        h.insert(("hello", 12, 2).into()).unwrap();
+        h.insert(("hello", 8..10).into()).unwrap();
+        h.insert(("hello", 10..12).into()).unwrap();
+        h.insert(("hello", 12..14).into()).unwrap();
         assert_eq!(3, h.len());
 
         // Test the entire object
-        let result = h.remove_range(0, 1000);
+        let result = h.remove_range(0..1000);
         assert_eq!(0, h.len());
         assert_eq!(3, result.len());
 
         assert_eq!("hello", result[0].entry);
-        assert_eq!(8,       result[0].index);
-        assert_eq!(2,       result[0].size);
+        assert_eq!(8..10,   result[0].range);
 
         assert_eq!("hello", result[1].entry);
-        assert_eq!(10,      result[1].index);
-        assert_eq!(2,       result[1].size);
+        assert_eq!(10..12,  result[1].range);
     }
 
     #[test]
     fn test_get() {
         // Create an object
         let mut h: BumpyVector<&str> = BumpyVector::new(100);
-        h.insert(("hello", 8, 2).into()).unwrap();
+        h.insert(("hello", 8..10).into()).unwrap();
 
         // Test removing the first two entries
         assert!(h.get(7).is_none());
@@ -921,7 +905,7 @@ mod tests {
     fn test_get_mut() {
         // Create an object
         let mut h: BumpyVector<String> = BumpyVector::new(100);
-        h.insert((String::from("hello"), 8, 2).into()).unwrap();
+        h.insert((String::from("hello"), 8..10).into()).unwrap();
 
         // Get a mutable reference
         let s = h.get_mut(9).unwrap();
@@ -935,7 +919,7 @@ mod tests {
     fn test_get_exact() {
         // Create an object
         let mut h: BumpyVector<&str> = BumpyVector::new(100);
-        h.insert(("hello", 8, 2).into()).unwrap();
+        h.insert(("hello", 8..10).into()).unwrap();
 
         // Test removing the first two entries
         assert!(h.get_exact(7).is_none());
@@ -948,7 +932,7 @@ mod tests {
     fn test_get_exact_mut() {
         // Create an object
         let mut h: BumpyVector<String> = BumpyVector::new(100);
-        h.insert((String::from("hello"), 8, 2).into()).unwrap();
+        h.insert((String::from("hello"), 8..10).into()).unwrap();
 
         // Make sure it's actually exist
         assert!(h.get_exact_mut(9).is_none());
@@ -970,28 +954,28 @@ mod tests {
         //        |   "a" (2)| "b" |            |      "c"       |
         //        +----------+------            +----------------+
         let mut h: BumpyVector<&str> = BumpyVector::new(10);
-        h.insert(("a", 1, 2).into()).unwrap();
-        h.insert(("b", 3, 1).into()).unwrap();
-        h.insert(("c", 6, 3).into()).unwrap();
+        h.insert(("a", 1..3).into()).unwrap();
+        h.insert(("b", 3..4).into()).unwrap();
+        h.insert(("c", 6..9).into()).unwrap();
 
         // Get just the first two
-        let result = h.get_range(2, 4);
+        let result = h.get_range(2..6);
         assert_eq!(2, result.len());
 
         // Get the first two, then just barely the third
-        let result = h.get_range(2, 5);
+        let result = h.get_range(2..7);
         assert_eq!(3, result.len());
 
         // Get the first two again, starting further left
-        let result = h.get_range(1, 5);
+        let result = h.get_range(1..6);
         assert_eq!(2, result.len());
 
         // Get all three again
-        let result = h.get_range(1, 6);
+        let result = h.get_range(1..7);
         assert_eq!(3, result.len());
 
         // Get way more than everything
-        let result = h.get_range(0, 100);
+        let result = h.get_range(0..100);
         assert_eq!(3, result.len());
     }
 
@@ -1004,29 +988,26 @@ mod tests {
         //        |   "a" (2)| "b" |            |      "c"       |
         //        +----------+------            +----------------+
         let mut h: BumpyVector<&str> = BumpyVector::new(10);
-        h.insert(("a", 1, 2).into()).unwrap();
-        h.insert(("b", 3, 1).into()).unwrap();
-        h.insert(("c", 6, 3).into()).unwrap();
+        h.insert(("a", 1..3).into()).unwrap();
+        h.insert(("b", 3..4).into()).unwrap();
+        h.insert(("c", 6..9).into()).unwrap();
 
         let mut iter = h.into_iter();
 
         // Entry "a" (index 1-2)
         let e = iter.next().unwrap();
-        assert_eq!("a", e.entry);
-        assert_eq!(1,   e.index);
-        assert_eq!(2,   e.size);
+        assert_eq!("a",  e.entry);
+        assert_eq!(1..3, e.range);
 
         // Entry "b" (index 3)
         let e = iter.next().unwrap();
-        assert_eq!("b", e.entry);
-        assert_eq!(3,   e.index);
-        assert_eq!(1,   e.size);
+        assert_eq!("b",  e.entry);
+        assert_eq!(3..4, e.range);
 
         // Entry "c" (index 6-8)
         let e = iter.next().unwrap();
-        assert_eq!("c", e.entry);
-        assert_eq!(6,   e.index);
-        assert_eq!(3,   e.size);
+        assert_eq!("c",  e.entry);
+        assert_eq!(6..9, e.range);
 
         // That's it!
         assert!(iter.next().is_none());
@@ -1037,9 +1018,9 @@ mod tests {
     #[cfg(feature = "serialize")] // Only test if we enable serialization
     fn test_serialize() {
         let mut h: BumpyVector<String> = BumpyVector::new(10);
-        h.insert((String::from("a"), 1, 2).into()).unwrap();
-        h.insert((String::from("b"), 3, 1).into()).unwrap();
-        h.insert((String::from("c"), 6, 3).into()).unwrap();
+        h.insert((String::from("a"), 1..3).into()).unwrap();
+        h.insert((String::from("b"), 3..4).into()).unwrap();
+        h.insert((String::from("c"), 6..9).into()).unwrap();
 
         // Serialize
         let serialized = ron::ser::to_string(&h).unwrap();
@@ -1048,37 +1029,33 @@ mod tests {
         let h: BumpyVector<String> = ron::de::from_str(&serialized).unwrap();
 
         // Make sure we have the same entries
-        assert_eq!("a", h.get(2).unwrap().entry);
-        assert_eq!(1,   h.get(2).unwrap().index);
-        assert_eq!(2,   h.get(2).unwrap().size);
-        assert_eq!("b", h.get(3).unwrap().entry);
+        assert_eq!("a",  h.get(2).unwrap().entry);
+        assert_eq!(1..3, h.get(2).unwrap().range);
+        assert_eq!("b",  h.get(3).unwrap().entry);
         assert!(h.get(4).is_none());
         assert!(h.get(5).is_none());
-        assert_eq!("c", h.get(6).unwrap().entry);
-        assert_eq!(6,   h.get(6).unwrap().index);
-        assert_eq!(3,   h.get(6).unwrap().size);
+        assert_eq!("c",  h.get(6).unwrap().entry);
+        assert_eq!(6..9, h.get(6).unwrap().range);
     }
 
     #[test]
     fn test_clone() {
         let mut h: BumpyVector<String> = BumpyVector::new(10);
-        h.insert((String::from("a"), 1, 2).into()).unwrap();
-        h.insert((String::from("b"), 3, 1).into()).unwrap();
-        h.insert((String::from("c"), 6, 3).into()).unwrap();
+        h.insert((String::from("a"), 1..3).into()).unwrap();
+        h.insert((String::from("b"), 3..4).into()).unwrap();
+        h.insert((String::from("c"), 6..9).into()).unwrap();
 
         // Serialize
         let cloned = h.clone();
 
         // Make sure we have the same entries
-        assert_eq!("a", cloned.get(2).unwrap().entry);
-        assert_eq!(1,   cloned.get(2).unwrap().index);
-        assert_eq!(2,   cloned.get(2).unwrap().size);
-        assert_eq!("b", cloned.get(3).unwrap().entry);
+        assert_eq!("a",  cloned.get(2).unwrap().entry);
+        assert_eq!(1..3, cloned.get(2).unwrap().range);
+        assert_eq!("b",  cloned.get(3).unwrap().entry);
         assert!(cloned.get(4).is_none());
         assert!(cloned.get(5).is_none());
-        assert_eq!("c", cloned.get(6).unwrap().entry);
-        assert_eq!(6,   cloned.get(6).unwrap().index);
-        assert_eq!(3,   cloned.get(6).unwrap().size);
+        assert_eq!("c",  cloned.get(6).unwrap().entry);
+        assert_eq!(6..9, cloned.get(6).unwrap().range);
     }
 
     #[test]
@@ -1089,12 +1066,8 @@ mod tests {
         };
 
         impl AutoBumpyEntry for Test {
-            fn index(&self) -> usize {
-                self.index
-            }
-
-            fn size(&self) -> usize {
-                self.size
+            fn range(&self) -> Range<usize> {
+                self.index..(self.index+self.size)
             }
         };
 


### PR DESCRIPTION
This breaks the API, but this isn't published yet so I'm okay with that.